### PR TITLE
refactor: add tests, use tracing, queue update notification only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2075,6 +2075,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tracing-test",
 ]
 
 [[package]]
@@ -4944,6 +4945,27 @@ dependencies = [
  "tracing",
  "tracing-core",
  "tracing-log",
+]
+
+[[package]]
+name = "tracing-test"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "557b891436fe0d5e0e363427fc7f217abf9ccd510d5136549847bdcbcd011d68"
+dependencies = [
+ "tracing-core",
+ "tracing-subscriber",
+ "tracing-test-macro",
+]
+
+[[package]]
+name = "tracing-test-macro"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04659ddb06c87d233c566112c1c9c5b9e98256d9af50ec3bc9c8327f873a7568"
+dependencies = [
+ "quote",
+ "syn 2.0.90",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,6 +2072,7 @@ dependencies = [
  "rand",
  "serde",
  "serde_bytes",
+ "testresult",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -4659,6 +4660,12 @@ dependencies = [
  "rustix",
  "windows-sys 0.59.0",
 ]
+
+[[package]]
+name = "testresult"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "614b328ff036a4ef882c61570f72918f7e9c5bee1da33f8e7f91e01daee7e56c"
 
 [[package]]
 name = "thiserror"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,4 +24,5 @@ tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 
 [dev-dependencies]
+testresult = "0.4.1"
 tracing-test = "0.2.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "iroh-loro"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
 anyhow = "1.0.80"
@@ -22,3 +22,6 @@ serde_bytes = "0.11.15"
 tokio = { version = "1.36.0", features = ["full"] }
 tracing = "0.1.41"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
+
+[dev-dependencies]
+tracing-test = "0.2.5"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,16 +4,20 @@ use std::{
     future::Future,
     pin::Pin,
     sync::{
-        Mutex,
         atomic::{self, AtomicBool},
+        Mutex,
     },
 };
 
 use anyhow::Result;
-use iroh::{endpoint::RecvStream, protocol::ProtocolHandler};
+use iroh::{
+    endpoint::{get_remote_node_id, ConnectionError, RecvStream},
+    protocol::ProtocolHandler,
+};
 use loro::{ExportMode, LoroDoc, VersionVector};
 use n0_future::{FuturesUnorderedBounded, StreamExt};
 use serde::{Deserialize, Serialize};
+use tracing::{debug, error, error_span, info, Instrument};
 
 #[derive(Debug, Clone)]
 pub struct IrohLoroProtocol {
@@ -66,7 +70,11 @@ impl IrohLoroProtocol {
 
     pub async fn respond_sync(&self, conn: iroh::endpoint::Connecting) -> Result<()> {
         let conn = conn.await?;
-        self.initiate_sync(conn, SyncMode::Continuous).await
+        let peer = get_remote_node_id(&conn)?;
+        info!(peer=%peer.fmt_short(),"incoming sync request");
+        self.initiate_sync(conn, SyncMode::Continuous)
+            .instrument(error_span!("accept", peer=%peer.fmt_short()))
+            .await
     }
 }
 
@@ -77,10 +85,9 @@ impl ProtocolHandler for IrohLoroProtocol {
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'static>> {
         let this = self.clone();
         Box::pin(async move {
-            println!("🔌 Peer connected");
             let result = this.respond_sync(conn).await;
             if let Err(e) = result {
-                println!("❌ Error: {e}");
+                error!("incoming sync request failed: {e}");
                 return Err(e);
             }
             Ok(())
@@ -101,9 +108,10 @@ struct RemoteState {
 
 impl SyncSession {
     async fn run_sync(&self) -> Result<()> {
-        let (tx, rx) = async_channel::bounded(128);
-        let _sub = self.doc.subscribe_local_update(Box::new(move |u| {
-            tx.send_blocking(u.clone()).unwrap();
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let _sub = self.doc.subscribe_local_update(Box::new(move |_u| {
+            info!("doc updated locally, queue update message");
+            tx.try_send(()).ok();
             true
         }));
 
@@ -115,13 +123,27 @@ impl SyncSession {
         loop {
             tokio::select! {
                 close = self.conn.closed() => {
-                    println!("🔌 Peer disconnected: {close:?}");
-                    return Ok(());
+                    info!("🔌 Peer disconnected: {close:?}");
+                    break;
                 },
                 // Accept incoming messages via uni-direction streams, if we have capacities to handle them
                 stream = self.conn.accept_uni(), if has_capacity(&pending_recv) && has_capacity(&pending_send) => {
                     // capacity checked in precondition above
-                    pending_recv.push(self.recv(stream?));
+                    match stream {
+                        Err(ConnectionError::ApplicationClosed(close)) => {
+                            info!("🔌 Peer disconnected: connection closed by peer {close:?}");
+                            break;
+                        },
+                        Err(ConnectionError::LocallyClosed) => {
+                            info!("🔌 Peer disconnected: connection closed by us");
+                            break;
+                        },
+                        Err(err) => {
+                            error!("🔌 Peer disconnected with error: {err:?}");
+                            return Err(err.into());
+                        }
+                        Ok(stream) => pending_recv.push(self.recv(stream)),
+                    }
                 },
                 // Work on receiving messages
                 Some(result) = pending_recv.next(), if has_capacity(&pending_send) => {
@@ -132,35 +154,36 @@ impl SyncSession {
                             }
                         }
                         Err(e) => {
-                            eprintln!("Receiving message failed: {e}");
+                            error!("Receiving message failed: {e}");
                         }
                     }
                 },
                 // Work on sending diffs
                 Some(result) = pending_send.next() => {
                     if let Err(e) = result {
-                        eprintln!("Sending message failed: {e}");
+                        error!("Sending message failed: {e}");
                     }
                 },
                 // Responses to local document changes
-                msg = rx.recv(), if has_capacity(&pending_send) => {
+                _ = rx.recv(), if has_capacity(&pending_send) && !rx.is_closed() => {
                     // capacity checked in precondition above
-                    pending_send.push(self.send(Message {
-                        diff: Some(Diff { bytes: msg?.into() }),
-                        ..Message::default()
-                    }));
+                    if let Some(message) = self.update_if_needed()? {
+                        pending_send.push(self.send(message));
+                    }
                 }
             }
         }
+        Ok(())
     }
 
     async fn recv(&self, mut stream: RecvStream) -> Result<()> {
         let msg = stream.read_to_end(10_000_000).await?; // 10 MB limit for now
         let message: Message<'_> = postcard::from_bytes(&msg)?;
-        println!(
-            "📥 Received sync msg from peer (size={} has_diff={})",
-            msg.len(),
-            message.diff.is_some()
+        info!(
+            size = msg.len(),
+            has_diff = message.diff.is_some(),
+            has_vv = message.version_vector.is_some(),
+            "Received sync msg from peer",
         );
 
         if let Some(vv) = &message.version_vector {
@@ -170,7 +193,7 @@ impl SyncSession {
 
         if let Some(diff) = message.diff {
             let status = self.doc.import(diff.as_ref())?;
-            println!(
+            info!(
                 "📥 Imported diff (pending={} any_successes={})",
                 status.pending.is_some(),
                 status.success.is_empty()
@@ -185,10 +208,11 @@ impl SyncSession {
 
     async fn send(&self, message: Message<'_>) -> Result<()> {
         let msg = postcard::to_allocvec(&message)?;
-        println!(
-            "📤 Sending sync msg to peer (size={} has_diff={})",
-            msg.len(),
-            message.diff.is_some()
+        info!(
+            size = msg.len(),
+            has_diff = message.diff.is_some(),
+            has_vv = message.version_vector.is_some(),
+            "Sending sync msg to peer",
         );
         let mut stream = self.conn.open_uni().await?;
         stream.write_all(&msg).await?;
@@ -203,7 +227,7 @@ impl SyncSession {
         Ok(match our_vv.partial_cmp(&remote.vv) {
             None => {
                 // We diverged: Send a diff and request to get a diff back, too
-                println!("⛓️‍💥 We are diverged");
+                info!("⛓️‍💥 We are diverged");
                 let diff = self.doc.export(ExportMode::updates(&remote.vv))?;
                 // We assume that the remote will eventually receive our message and be on our state
                 remote.vv.extend_to_include_vv(our_vv.iter());
@@ -215,11 +239,11 @@ impl SyncSession {
             }
             Some(Ordering::Greater) => {
                 // We're ahead: Send a diff, but no need to tell the other side to update us
-                println!("📈 We are ahead");
+                info!("📈 We are ahead");
                 let diff = self.doc.export(ExportMode::updates(&remote.vv))?;
                 // We assume that the remote will eventually receive our message and be on our state
                 remote.vv.extend_to_include_vv(our_vv.iter());
-                println!("🤝 Assuming to be in sync once peer receives this");
+                info!("🤝 Assuming to be in sync once peer receives this");
                 Some(Message {
                     version_vector: None,
                     close_when_done,
@@ -228,7 +252,7 @@ impl SyncSession {
             }
             Some(Ordering::Less) => {
                 // We are behind: we inform the other side about what we're missing, apparently we didn't get it
-                println!("📉 We are behind");
+                info!("📉 We are behind");
                 Some(Message {
                     version_vector: Some(our_vv),
                     close_when_done,
@@ -236,7 +260,7 @@ impl SyncSession {
                 })
             }
             Some(Ordering::Equal) => {
-                println!("🤝 In sync with peer");
+                info!("🤝 In sync with peer");
                 if close_when_done {
                     self.conn.close(0u32.into(), b"in sync, thank you");
                 }
@@ -267,5 +291,130 @@ struct Diff<'a> {
 impl<'a> AsRef<[u8]> for Diff<'a> {
     fn as_ref(&self) -> &[u8] {
         self.bytes.as_ref()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    use std::{sync::Arc, time::Duration};
+
+    use iroh::protocol::Router;
+    use loro::{EventTriggerKind, LoroDoc};
+    use tracing::{error_span, info, Instrument};
+    use tracing_test::traced_test;
+
+    use crate::{IrohLoroProtocol, SyncMode};
+
+    async fn setup_node(doc: LoroDoc) -> anyhow::Result<(Router, IrohLoroProtocol)> {
+        let proto = IrohLoroProtocol::new(doc);
+        let endpoint = iroh::Endpoint::builder().bind().await?;
+
+        // Create and configure iroh node
+        let router = iroh::protocol::Router::builder(endpoint)
+            .accept(IrohLoroProtocol::ALPN, proto.clone())
+            .spawn()
+            .await?;
+        Ok((router, proto))
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn basic() {
+        let doc_a = LoroDoc::new();
+        let doc_b = LoroDoc::new();
+        doc_b
+            .get_text("text")
+            .update("hello", Default::default())
+            .unwrap();
+        assert_eq!(doc_b.get_text("text").to_string().as_str(), "hello");
+        assert_eq!(doc_a.get_text("text").to_string().as_str(), "");
+
+        let (router_a, proto_a) = setup_node(doc_a.clone()).await.unwrap();
+        let (router_b, _proto_b) = setup_node(doc_b.clone()).await.unwrap();
+
+        let addr_b = router_b.endpoint().node_addr().await.unwrap();
+
+        let conn_a_to_b = router_a
+            .endpoint()
+            .connect(addr_b.clone(), IrohLoroProtocol::ALPN)
+            .await
+            .unwrap();
+
+        proto_a
+            .initiate_sync(conn_a_to_b, SyncMode::Once)
+            .instrument(error_span!("connect", peer = %addr_b.node_id.fmt_short()))
+            .await
+            .unwrap();
+
+        assert_eq!(doc_b.get_text("text").to_string().as_str(), "hello");
+        assert_eq!(doc_a.get_text("text").to_string().as_str(), "hello");
+    }
+
+    #[tokio::test]
+    #[traced_test]
+    async fn updates() {
+        let doc_a = LoroDoc::new();
+        let doc_b = LoroDoc::new();
+        let (router_a, proto_a) = setup_node(doc_a.clone()).await.unwrap();
+        let (router_b, _proto_b) = setup_node(doc_b.clone()).await.unwrap();
+
+        let addr_b = router_b.endpoint().node_addr().await.unwrap();
+
+        let conn_a_to_b = router_a
+            .endpoint()
+            .connect(addr_b.clone(), IrohLoroProtocol::ALPN)
+            .await
+            .unwrap();
+
+        let _t = tokio::task::spawn(async move {
+            proto_a
+                .initiate_sync(conn_a_to_b, SyncMode::Continuous)
+                .instrument(error_span!("connect", peer = %addr_b.node_id.fmt_short()))
+                .await
+                .unwrap();
+        });
+
+        // setup update listener channels
+        let (update_a_tx, mut update_a_rx) = tokio::sync::mpsc::channel(1);
+        let _sub = doc_a.subscribe_root(Arc::new(move |update| {
+            if update.triggered_by == EventTriggerKind::Import {
+                update_a_tx.try_send(()).ok();
+            }
+        }));
+        let (update_b_tx, mut update_b_rx) = tokio::sync::mpsc::channel(1);
+        let _sub = doc_b.subscribe_root(Arc::new(move |update| {
+            if update.triggered_by == EventTriggerKind::Import {
+                update_b_tx.try_send(()).ok();
+            }
+        }));
+
+        info!("now update text on a");
+        doc_a
+            .get_text("text")
+            .update("a", Default::default())
+            .unwrap();
+        doc_a.commit();
+        let _ = tokio::time::timeout(Duration::from_millis(500), update_b_rx.recv())
+            .await
+            .expect("did not receive update within timeout")
+            .expect("update channel closed before receiving update");
+
+        info!("b received update from a");
+        assert_eq!(doc_b.get_text("text").to_string().as_str(), "a");
+
+        info!("now update text on b");
+        doc_b
+            .get_text("text")
+            .update("b", Default::default())
+            .unwrap();
+        doc_b.commit();
+
+        let _ = tokio::time::timeout(Duration::from_millis(1000), update_a_rx.recv())
+            .await
+            .expect("did not receive update within timeout")
+            .expect("update channel closed before receiving update");
+        info!("a received update from b");
+        assert_eq!(doc_a.get_text("text").to_string().as_str(), "b");
     }
 }


### PR DESCRIPTION
* use `tracing` instead of `println`
* add two basic tests: one for a simple once sync, one for a sync with updates from both sides
* queue local updates only as notfication in the main sync loop, and calculate the actual update message on demand, to prevent blocking on a full channel of updates when the network is not fast enough